### PR TITLE
chore(dependencies): remove sonata datagrid bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ master
 
 * Add Composer keyword for asking user to add this package to require-dev instead of require
 * Fix tests by changing MethodReflection to expected ExtendedMethodRepository
+* Remove sonata-project/datagrid-bundle dependency
 
 v1.0.0
 ------

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "phpstan/phpstan": "^1.0",
-        "sonata-project/datagrid-bundle": "^3.0",
+        "sonata-project/admin-bundle": "^3.107 || ^4.20",
         "sonata-project/doctrine-orm-admin-bundle": "^3.6"
     },
     "require-dev": {

--- a/src/Type/ProxyQueryDynamicReturnTypeExtension.php
+++ b/src/Type/ProxyQueryDynamicReturnTypeExtension.php
@@ -19,8 +19,7 @@ use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as AdminProxyQueryInterface;
-use Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface as DatagridProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 
 /**
@@ -46,7 +45,7 @@ class ProxyQueryDynamicReturnTypeExtension implements MethodsClassReflectionExte
      */
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
-        return (\in_array($classReflection->getName(), [AdminProxyQueryInterface::class, DatagridProxyQueryInterface::class, ProxyQuery::class])
+        return (\in_array($classReflection->getName(), [ProxyQueryInterface::class, ProxyQuery::class])
             && $this->broker->getClass(QueryBuilder::class)->hasMethod($methodName));
     }
 

--- a/tests/Type/ProxyQueryDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/ProxyQueryDynamicReturnTypeExtensionTest.php
@@ -21,8 +21,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPUnit\Framework\TestCase;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as AdminProxyQueryInterface;
-use Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface as DatagridProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 
 /**
@@ -86,10 +85,8 @@ class ProxyQueryDynamicReturnTypeExtensionTest extends TestCase
         yield 'wrong class & valid method' => [false, 'Foo\Bar', true, 'leftJoin', 0];
         yield 'proxy query & valid method' => [true, ProxyQuery::class, true, 'leftJoin', 1];
         yield 'proxy query & wrong method' => [false, ProxyQuery::class, false, 'foo', 1];
-        yield 'admin proxy query & valid method' => [true, AdminProxyQueryInterface::class, true, 'leftJoin', 1];
-        yield 'admin proxy query & wrong method' => [false, AdminProxyQueryInterface::class, false, 'foo', 1];
-        yield 'datagrid proxy query & valid method' => [true, DatagridProxyQueryInterface::class, true, 'leftJoin', 1];
-        yield 'datagrid proxy query & wrong method' => [false, DatagridProxyQueryInterface::class, false, 'foo', 1];
+        yield 'admin proxy query & valid method' => [true, ProxyQueryInterface::class, true, 'leftJoin', 1];
+        yield 'admin proxy query & wrong method' => [false, ProxyQueryInterface::class, false, 'foo', 1];;
     }
 
     /**


### PR DESCRIPTION
https://github.com/sonata-project/SonataDatagridBundle is archived, so we have to remove if from requirements