### PR TITLE
fix: be able to use it with orm 4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ master
 * Add Composer keyword for asking user to add this package to require-dev instead of require
 * Fix tests by changing MethodReflection to expected ExtendedMethodRepository
 * Remove sonata-project/datagrid-bundle dependency
+* Bump sonata-project/doctrine-orm-admin-bundle to 4.3
+
 
 v1.0.0
 ------

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^7.3 || ^8.0",
         "phpstan/phpstan": "^1.0",
         "sonata-project/admin-bundle": "^3.107 || ^4.20",
-        "sonata-project/doctrine-orm-admin-bundle": "^3.6"
+        "sonata-project/doctrine-orm-admin-bundle": "^3.6 || ^4.3"
     },
     "require-dev": {
         "nikic/php-parser": "^4.3",


### PR DESCRIPTION
We were using `dev-dependabot/composer/sonata-project/doctrine-orm-admin-bundle-tw-4.3` but this branch has been deleted